### PR TITLE
fix: typo correction README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ this will build the binary `bin/host/target/release/reva` for your host architec
 
 ### Running the Host application
 
-Running the host application will generate an input file to be used by the target/client application. Simply suppply a block number, a chain ID (1 for ethereum, 10 for OP), and an RPC URL:
+Running the host application will generate an input file to be used by the target/client application. Simply supply a block number, a chain ID (1 for ethereum, 10 for OP), and an RPC URL:
 
 ```console
 ./bin/host/target/release/reva --block-number 20000005 --chain-id 1 --rpc-url <RPC>


### PR DESCRIPTION
Hi! I fixed a typo in the README.md file:
![image](https://github.com/user-attachments/assets/e492f82f-2c7e-4549-b8e2-526227c86cc5)
![image](https://github.com/user-attachments/assets/e924f92a-458e-4e60-b841-44b08ec5c98c)
