### PR TITLE
Fix build by adding config.toml.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+[build]
+target = "valida-unknown-baremetal-gnu"
+
+[target.valida-unknown-baremetal-gnu]
+linker = "/valida-toolchain/bin/ld.lld"
+rustflags = [
+    "-C", "link-arg=/valida-toolchain/ValidaEntryPoint.o",
+    "-C", "link-arg=/valida-toolchain/io.o",
+    "-C", "link-arg=--script=/valida-toolchain/valida.ld",
+    "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libc.a",
+    "-C", "link-arg=/valida-toolchain/lib/valida-unknown-baremetal-gnu/libm.a",
+]
+
+[env]
+CC_valida_unknown_baremetal_gnu = "/valida-toolchain/bin/clang"
+CFLAGS_valida_unknown_baremetal_gnu = "--sysroot=/valida-toolchain/ -isystem /valida-toolchain/include"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Cargo build
 **/target
 
-# Cargo config
-.cargo
-
 # Profile-guided optimization
 /tmp
 pgo-data.profdata


### PR DESCRIPTION
Closes #7 

Note that we will probably want to revert this in our next release, which will have incorporated these into a modified `cargo.git`.