### PR TITLE
Update alloy-primitives to point to Lita's fork.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,5 +137,5 @@ c-kzg = { git = "https://github.com/lita-xyz/c-kzg-4844.git", branch = "1.0.3-de
 zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
 proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
 pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida" }
-alloy-primitives = { git = "https://github.com/lewis1revill/core", branch = "0.8.15-valida" }
+alloy-primitives = { git = "https://github.com/lita-xyz/core" }
 alloy-chains = { git = "https://github.com/lita-xyz/chains", branch = "ljr-fix-hex" }

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -27,5 +27,8 @@ c-kzg = { git = "https://github.com/lita-xyz/c-kzg-4844.git", branch = "1.0.3-de
 zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
 proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
 pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida" }
-alloy-primitives = { git = "https://github.com/lewis1revill/core", branch = "0.8.15-valida" }
+alloy-primitives = { git = "https://github.com/lita-xyz/core" }
 alloy-chains = { git = "https://github.com/lita-xyz/chains", branch = "ljr-fix-hex" }
+
+[profile.release]
+lto = false


### PR DESCRIPTION
Point to Lita's fork of `core` so that it points to the patched [`tiny-keccak`](https://github.com/lita-xyz/tiny-keccak) https://github.com/alloy-rs/core/commit/d2e1b98babd2f50c39f6a4e874bfbef674600449