### PR TITLE
Reenable LTO in release mode

### DIFF
--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -30,5 +30,3 @@ pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida"
 alloy-primitives = { git = "https://github.com/lita-xyz/core" }
 alloy-chains = { git = "https://github.com/lita-xyz/chains", branch = "ljr-fix-hex" }
 
-[profile.release]
-lto = false


### PR DESCRIPTION
I tested it manually against one block and it returned a correct hash