### PR TITLE
Fix typo in initialization comments

### DIFF
--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -23,7 +23,7 @@ struct HostArgs {
 
 #[tokio::main]
 async fn main() {
-    // Intialize the environment variables.
+    // Initialize the environment variables.
     dotenv::dotenv().ok();
 
     if std::env::var("RUST_LOG").is_err() {

--- a/crates/executor/host/tests/integration.rs
+++ b/crates/executor/host/tests/integration.rs
@@ -28,7 +28,7 @@ async fn run_e2e<V>(variant: ChainVariant, env_var_key: &str, block_number: u64)
 where
     V: Variant,
 {
-    // Intialize the environment variables.
+    // Initialize the environment variables.
     dotenv::dotenv().ok();
 
     // Initialize the logger.


### PR DESCRIPTION
This PR fixes a typo in comments where "Intialize" was incorrectly spelled. 
Changed to the correct spelling "Initialize" in:
- bin/host/src/main.rs
- crates/executor/host/tests/integration.rs