### PR TITLE
Cleanup `reva` forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,8 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
-source = "git+https://github.com/lita-xyz/proptest?branch=1.5.0-valida#58ea8c0991cfb2a579a2dab778a3b5e252017de2"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -4829,7 +4830,8 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 [[package]]
 name = "rusty-fork"
 version = "0.3.0"
-source = "git+https://github.com/lita-xyz/rusty-fork?branch=0.3.0-valida#cd0553d1b9863acae3e87a346d4de3f7127b24b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
  "quick-error",
@@ -5842,8 +5844,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
-source = "git+https://github.com/lita-xyz/wait-timeout?branch=0.2.0-valida#3e94589e36c649197155e3635ee0735e2f1d3f7b"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -6322,39 +6325,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "git+https://github.com/lita-xyz/zstd-rs.git?branch=zstd-sys-2.0.13-delendum#c8dcd227cb5bb8e02fd786bdac4a3cb0ef7c4c0d"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "alloy-chains"
-version = "0.1.53"
-source = "git+https://github.com/lita-xyz/chains?branch=ljr-fix-hex#59e554e4711cc40cb399132823b83afd42548bea"
-
-[[patch.unused]]
-name = "blst"
-version = "0.3.13"
-source = "git+https://github.com/lita-xyz/blst.git?branch=0.3.13-delendum#0b37404e47d5736ec0a051e222842a696eec7b82"
-
-[[patch.unused]]
-name = "c-kzg"
-version = "1.0.3"
-source = "git+https://github.com/lita-xyz/c-kzg-4844.git?branch=1.0.3-delendum#452bb46ef717b7946f51431bfe46484358149f52"
-
-[[patch.unused]]
-name = "cc"
-version = "1.1.18"
-source = "git+https://github.com/lita-xyz/cc-rs.git?branch=1.1.18-delendum#92233fca5ad8f2430270032e1599b292d6e9d112"
-
-[[patch.unused]]
-name = "is-terminal"
-version = "0.4.13"
-source = "git+https://github.com/lita-xyz/is-terminal?branch=0.4.13-valida#81762f5f1de6c5f177afbcfc57862ad4f8d2dbf6"
-
-[[patch.unused]]
-name = "pprof"
-version = "0.13.0"
-source = "git+https://github.com/lita-xyz/pprof-rs?branch=0.13.0-valida#d5c7ff59ee3eb949029cb5ddba71dbcd71faa09b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,16 +130,6 @@ rustdoc.all = "warn"
 
 [patch.crates-io]
 foldhash = { git = "https://github.com/lita-xyz/foldhash", branch = "v0.1.4-valida" }
-wait-timeout = { git = "https://github.com/lita-xyz/wait-timeout", branch = "0.2.0-valida" }
-rusty-fork = { git = "https://github.com/lita-xyz/rusty-fork", branch = "0.3.0-valida" }
-is-terminal = { git = "https://github.com/lita-xyz/is-terminal", branch = "0.4.13-valida" }
-cc = { git = "https://github.com/lita-xyz/cc-rs.git", branch = "1.1.18-delendum" }
-blst = { git = "https://github.com/lita-xyz/blst.git", branch = "0.3.13-delendum" }
-c-kzg = { git = "https://github.com/lita-xyz/c-kzg-4844.git", branch = "1.0.3-delendum" }
-zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
-proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
-pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida" }
-alloy-chains = { git = "https://github.com/lita-xyz/chains", branch = "ljr-fix-hex" }
 secp256k1 = { git = "https://github.com/lita-xyz/rust-secp256k1.git", rev = "dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4" }
 tiny-keccak = { git = "https://github.com/lita-xyz/tiny-keccak.git" }
 getrandom = { git = "https://github.com/lita-xyz/getrandom.git", branch = "v0.2.16-valida" }

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -2660,8 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
-source = "git+https://github.com/lita-xyz/proptest?branch=1.5.0-valida#58ea8c0991cfb2a579a2dab778a3b5e252017de2"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3625,7 +3626,8 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 [[package]]
 name = "rusty-fork"
 version = "0.3.0"
-source = "git+https://github.com/lita-xyz/rusty-fork?branch=0.3.0-valida#cd0553d1b9863acae3e87a346d4de3f7127b24b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
  "quick-error",
@@ -4352,8 +4354,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
-source = "git+https://github.com/lita-xyz/wait-timeout?branch=0.2.0-valida#3e94589e36c649197155e3635ee0735e2f1d3f7b"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -4707,8 +4710,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "git+https://github.com/lita-xyz/zstd-rs.git?branch=zstd-sys-2.0.13-delendum#c8dcd227cb5bb8e02fd786bdac4a3cb0ef7c4c0d"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -16,10 +16,6 @@ tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off
 
 [patch.crates-io]
 foldhash = { git = "https://github.com/lita-xyz/foldhash", branch = "v0.1.4-valida" }
-wait-timeout = { git = "https://github.com/lita-xyz/wait-timeout", branch = "0.2.0-valida" }
-rusty-fork = { git = "https://github.com/lita-xyz/rusty-fork", branch = "0.3.0-valida" }
-zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
-proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
 secp256k1 = { git = "https://github.com/lita-xyz/rust-secp256k1.git", rev = "dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4" }
 tiny-keccak = { git = "https://github.com/lita-xyz/tiny-keccak.git" }
 getrandom = { git = "https://github.com/lita-xyz/getrandom.git", branch = "v0.2.16-valida" }

--- a/bin/client-op/Cargo.lock
+++ b/bin/client-op/Cargo.lock
@@ -1559,6 +1559,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "byteorder",
  "ff_derive",
  "rand_core 0.6.4",
@@ -2754,8 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
-source = "git+https://github.com/lita-xyz/proptest?branch=1.5.0-valida#58ea8c0991cfb2a579a2dab778a3b5e252017de2"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -3836,7 +3838,8 @@ checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 [[package]]
 name = "rusty-fork"
 version = "0.3.0"
-source = "git+https://github.com/lita-xyz/rusty-fork?branch=0.3.0-valida#cd0553d1b9863acae3e87a346d4de3f7127b24b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
  "quick-error",
@@ -3868,20 +3871,19 @@ dependencies = [
 [[package]]
 name = "secp256k1"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+source = "git+https://github.com/lita-xyz/rust-secp256k1.git?rev=dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4#dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
+ "valida-secp256k1",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+version = "0.10.0"
+source = "git+https://github.com/lita-xyz/rust-secp256k1.git?rev=dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4#dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4"
 dependencies = [
  "cc",
 ]
@@ -4327,8 +4329,7 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+source = "git+https://github.com/lita-xyz/tiny-keccak.git#e06385504bbb44005df50796df6e45f8d0ef235f"
 dependencies = [
  "crunchy",
 ]
@@ -4534,6 +4535,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valida-intrinsics"
+version = "0.1.0"
+source = "git+https://github.com/lita-xyz/valida-intrinsics.git?rev=9a954d056eedec7d4506729cca84dbcc226c47c7#9a954d056eedec7d4506729cca84dbcc226c47c7"
+
+[[package]]
+name = "valida-secp256k1"
+version = "0.1.0"
+source = "git+https://github.com/lita-xyz/valida-secp256k1.git?rev=d7359dd742202fb48c38e58a5aac53186d3151fb#d7359dd742202fb48c38e58a5aac53186d3151fb"
+dependencies = [
+ "const-hex",
+ "ff",
+ "hex",
+ "k256",
+ "valida-intrinsics",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4547,8 +4565,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
-source = "git+https://github.com/lita-xyz/wait-timeout?branch=0.2.0-valida#3e94589e36c649197155e3635ee0735e2f1d3f7b"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -4921,31 +4940,6 @@ dependencies = [
 ]
 
 [[patch.unused]]
-name = "blst"
-version = "0.3.13"
-source = "git+https://github.com/lita-xyz/blst.git?branch=0.3.13-delendum#0b37404e47d5736ec0a051e222842a696eec7b82"
-
-[[patch.unused]]
-name = "c-kzg"
-version = "1.0.3"
-source = "git+https://github.com/lita-xyz/c-kzg-4844.git?branch=1.0.3-delendum#452bb46ef717b7946f51431bfe46484358149f52"
-
-[[patch.unused]]
-name = "cc"
-version = "1.1.18"
-source = "git+https://github.com/lita-xyz/cc-rs.git?branch=1.1.18-delendum#92233fca5ad8f2430270032e1599b292d6e9d112"
-
-[[patch.unused]]
-name = "is-terminal"
-version = "0.4.13"
-source = "git+https://github.com/lita-xyz/is-terminal?branch=0.4.13-valida#81762f5f1de6c5f177afbcfc57862ad4f8d2dbf6"
-
-[[patch.unused]]
-name = "pprof"
-version = "0.13.0"
-source = "git+https://github.com/lita-xyz/pprof-rs?branch=0.13.0-valida#d5c7ff59ee3eb949029cb5ddba71dbcd71faa09b"
-
-[[patch.unused]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "git+https://github.com/lita-xyz/zstd-rs.git?branch=zstd-sys-2.0.13-delendum#c8dcd227cb5bb8e02fd786bdac4a3cb0ef7c4c0d"
+name = "foldhash"
+version = "0.1.4"
+source = "git+https://github.com/lita-xyz/foldhash?branch=v0.1.4-valida#fe46b016b73534db97de2d1c14ce47a8cad0144c"

--- a/bin/client-op/Cargo.toml
+++ b/bin/client-op/Cargo.toml
@@ -15,13 +15,7 @@ log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
 tracing = { version = "0.1", features = ["max_level_off", "release_max_level_off"] }
 
 [patch.crates-io]
-wait-timeout = { git = "https://github.com/lita-xyz/wait-timeout", branch = "0.2.0-valida" }
-rusty-fork = { git = "https://github.com/lita-xyz/rusty-fork", branch = "0.3.0-valida" }
-is-terminal = { git = "https://github.com/lita-xyz/is-terminal", branch = "0.4.13-valida" }
-cc = { git = "https://github.com/lita-xyz/cc-rs.git", branch = "1.1.18-delendum" }
-blst = { git = "https://github.com/lita-xyz/blst.git", branch = "0.3.13-delendum" }
-c-kzg = { git = "https://github.com/lita-xyz/c-kzg-4844.git", branch = "1.0.3-delendum" }
-zstd-sys = { git = "https://github.com/lita-xyz/zstd-rs.git", branch = "zstd-sys-2.0.13-delendum" }
-proptest = { git = "https://github.com/lita-xyz/proptest", branch = "1.5.0-valida" }
-pprof = { git = "https://github.com/lita-xyz/pprof-rs", branch = "0.13.0-valida" }
+foldhash = { git = "https://github.com/lita-xyz/foldhash", branch = "v0.1.4-valida" }
+secp256k1 = { git = "https://github.com/lita-xyz/rust-secp256k1.git", rev = "dcccf7bb5a54da66a130d0d5b2181e88d85fcfb4" }
+tiny-keccak = { git = "https://github.com/lita-xyz/tiny-keccak.git" }
 getrandom = { git = "https://github.com/lita-xyz/getrandom.git", branch = "v0.2.16-valida" }


### PR DESCRIPTION
`bin/client-eth` and `bin/client-op` compile without most of the forks.
